### PR TITLE
Update stackdriver parser to check prefixes of method names instead of exact strings

### DIFF
--- a/app/lib/stackdriver.py
+++ b/app/lib/stackdriver.py
@@ -50,14 +50,17 @@ class StackdriverParser():
         list is going to be annoying. Long term, this entire class  should be
         replaced when google provides a real-time event delivery solution '''
 
-        last = method_name.split('.')[-1]
-        if last in ['list', 'get', 'List']:
+        last = method_name.split('.')[-1].lower()
+        read_prefixes = ('get', 'list')
+        if last.startswith(read_prefixes):
             return 'read'
 
-        if last in ['create', 'update', 'InsertDataset', 'PatchDataset', 'setIamPermissions', 'SetIamPolicy']:
+        write_prefixes = ('create', 'update', 'insert', 'patch', 'set')
+        if last.startswith(write_prefixes):
             return 'write'
 
-        if last in ['delete']:
+        delete_prefixes = ('delete')
+        if last.startswith(delete_prefixes):
             return 'delete'
 
         else:


### PR DESCRIPTION
Some bigquery logs are not being properly detected as write operations. As a result, nothing is evaluated or remediated. This changes how we detect the type of operation to look at the prefix of the method name, rather than the exact string match.