### PR TITLE
Fix/project services

### DIFF
--- a/app/lib/stackdriver.py
+++ b/app/lib/stackdriver.py
@@ -59,7 +59,7 @@ class StackdriverParser():
         if last.startswith(read_prefixes):
             return 'read'
 
-        write_prefixes = ('create', 'update', 'insert', 'patch', 'set', 'debug', 'enable', 'disable', 'expand')
+        write_prefixes = ('create', 'update', 'insert', 'patch', 'set', 'debug', 'enable', 'disable', 'expand', 'deactivate', 'activate')
         if last.startswith(write_prefixes):
             return 'write'
 
@@ -153,14 +153,15 @@ class StackdriverParser():
             resource_location = ''
             add_resource()
 
-        elif res_type == 'audited_resource' and ('EnableService' in method_name or 'DisableService' in method_name):
+        elif res_type == 'audited_resource' and ('EnableService' in method_name or 'DisableService' in method_name or 'ctivateService' in method_name):
 
             resource_type = 'serviceusage.services'
             project_id = prop("resource.labels.project_id")
             resource_location = ''
 
             # Check if multiple services were included in the request
-            services = prop('protoPayload.request.serviceIds')
+            # The Google Cloud Console generates (De)activate calls that logs a different format so we check both known formats
+            services = prop('protoPayload.request.serviceIds') or prop('protoPayload.request.serviceNames')
             if services:
                 for s in services:
                     resource_name = s

--- a/app/lib/stackdriver.py
+++ b/app/lib/stackdriver.py
@@ -59,7 +59,7 @@ class StackdriverParser():
         if last.startswith(read_prefixes):
             return 'read'
 
-        write_prefixes = ('create', 'update', 'insert', 'patch', 'set', 'debug', 'enable', 'expand')
+        write_prefixes = ('create', 'update', 'insert', 'patch', 'set', 'debug', 'enable', 'disable', 'expand')
         if last.startswith(write_prefixes):
             return 'write'
 
@@ -153,7 +153,7 @@ class StackdriverParser():
             resource_location = ''
             add_resource()
 
-        elif res_type == 'audited_resource' and 'EnableService' in method_name:
+        elif res_type == 'audited_resource' and ('EnableService' in method_name or 'DisableService' in method_name):
 
             resource_type = 'serviceusage.services'
             project_id = prop("resource.labels.project_id")

--- a/tests/data/servicemanagement-activate-service.json
+++ b/tests/data/servicemanagement-activate-service.json
@@ -1,0 +1,77 @@
+ {
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.ActivateServices",
+    "authorizationInfo": [
+      {
+        "resource": "services/calendar-json.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/calendar-json.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/calendar-json.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.enable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/[calendar-json.googleapis.com]",
+    "request": {
+      "consumerProjectId": "my-project",
+      "serviceNames": [
+        "calendar-json.googleapis.com"
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.ActivateServicesRequest"
+    },
+    "response": {
+      "settings": [
+        {
+          "serviceName": "calendar-json.googleapis.com",
+          "usageSettings": {
+            "consumerEnableStatus": "ENABLED"
+          }
+        }
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.ActivateServicesResponse"
+    }
+  },
+  "insertId": "-dvbh0bc0w0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "servicemanagement.googleapis.com",
+      "method": "google.api.servicemanagement.v0.ServiceManager.ActivateServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.00f000a0-0e00-0bc0-0000-000a0000ce00",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-deactivate-service.json
+++ b/tests/data/servicemanagement-deactivate-service.json
@@ -1,0 +1,66 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.DeactivateServices",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.disable",
+        "granted": true
+      },
+      {
+        "resource": "services/zync.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/zync.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.disable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/[zync.googleapis.com]",
+    "request": {
+      "consumerProjectId": "my-project",
+      "serviceNames": [
+        "zync.googleapis.com"
+      ],
+      "errorWhenDeactivatingDependentServices": true,
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DeactivateServicesRequest"
+    },
+    "response": {
+      "settings": [
+        {
+          "serviceName": "zync.googleapis.com",
+          "usageSettings": {}
+        }
+      ],
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DeactivateServicesResponse"
+    }
+  },
+  "insertId": "-lwk00yc0qk",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "servicemanagement.googleapis.com",
+      "method": "google.api.servicemanagement.v0.ServiceManager.DeactivateServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.00dff0e0-ae0e-00fd-a0b0-cd00bb00b00d",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-disable-service.json
+++ b/tests/data/servicemanagement-disable-service.json
@@ -1,0 +1,57 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.DisableService",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.disable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.disable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/youtubereporting.googleapis.com",
+    "request": {
+      "serviceName": "youtubereporting.googleapis.com",
+      "consumerId": "project:my-project",
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DisableServiceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.DisableServiceResponse"
+    }
+  },
+  "insertId": "-gmzpb0c0v0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.api.servicemanagement.v0.ServiceManager.DisableService",
+      "project_id": "my-project",
+      "service": "servicemanagement.googleapis.com"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.b00c0000-00c0-00ff-000c-00db0cba00fb",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/data/servicemanagement-enable-service.json
+++ b/tests/data/servicemanagement-enable-service.json
@@ -1,0 +1,67 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "servicemanagement.googleapis.com",
+    "methodName": "google.api.servicemanagement.v0.ServiceManager.EnableService",
+    "authorizationInfo": [
+      {
+        "resource": "services/youtubeadsreach.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/-",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubeadsreach.googleapis.com",
+        "permission": "servicemanagement.services.bindAll"
+      },
+      {
+        "resource": "services/youtubeadsreach.googleapis.com/consumers/000000000000",
+        "permission": "serviceconsumermanagement.consumers.enable"
+      }
+    ],
+    "resourceName": "projects/000000000000/services/youtubeadsreach.googleapis.com",
+    "request": {
+      "serviceName": "youtubeadsreach.googleapis.com",
+      "consumerId": "project:my-project",
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.EnableServiceRequest"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.api.servicemanagement.v0.EnableServiceResponse"
+    }
+  },
+  "insertId": "0e0000c0z0",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "method": "google.api.servicemanagement.v0.ServiceManager.EnableService",
+      "project_id": "my-project",
+      "service": "servicemanagement.googleapis.com"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.dbfd000c-a0ff-0000-0d00-0e00f0fc00ad",
+    "producer": "servicemanagement.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/data/serviceusage-batchenable.json
+++ b/tests/data/serviceusage-batchenable.json
@@ -1,0 +1,74 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "00.00.000.000",
+      "callerSuppliedUserAgent": "Mozilla/0.0 (Macintosh; Intel Mac OS X 00.00; rv:00.0) Gecko/00000000 Firefox/00.0,gzip(gfe)"
+    },
+    "serviceName": "serviceusage.googleapis.com",
+    "methodName": "google.api.serviceusage.v0.ServiceUsage.BatchEnableServices",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/toolresults.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/toolresults.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/travelpartner.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/travelpartner.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      },
+      {
+        "resource": "projectnumbers/000000000000/services/tpu.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/tpu.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      }
+    ],
+    "resourceName": "projects/my-project/services",
+    "request": {
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.BatchEnableServicesRequest",
+      "parent": "projects/my-project",
+      "serviceIds": [
+        "toolresults.googleapis.com",
+        "travelpartner.googleapis.com",
+        "tpu.googleapis.com"
+      ]
+    }
+  },
+  "insertId": "0pbj0omc0al",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "serviceusage.googleapis.com",
+      "method": "google.api.serviceusage.v0.ServiceUsage.BatchEnableServices",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.000000f0-cbf0-00b0-0e00-d000b000b00b",
+    "producer": "serviceusage.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/data/serviceusage-disable.json
+++ b/tests/data/serviceusage-disable.json
@@ -1,0 +1,56 @@
+{
+ "protoPayload": {
+   "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+   "status": {},
+   "authenticationInfo": {
+     "principalEmail": "user@example.com"
+   },
+   "requestMetadata": {
+     "callerIp": "0:0:0:0:0:0:0:0",
+     "callerSuppliedUserAgent": "unknown"
+   },
+   "serviceName": "serviceusage.googleapis.com",
+   "methodName": "google.api.serviceusage.v0.ServiceUsage.DisableService",
+   "authorizationInfo": [
+     {
+       "resource": "projectnumbers/000000000000/services/zync.googleapis.com",
+       "permission": "serviceusage.services.disable",
+       "granted": true
+     }
+   ],
+   "resourceName": "projects/my-project/services/zync.googleapis.com",
+   "request": {
+     "name": "projects/my-project/services/zync.googleapis.com",
+     "@type": "type.googleapis.com/google.api.serviceusage.v0.DisableServiceRequest"
+   },
+   "response": {
+     "service": {
+       "name": "projects/000000000000/services/zync.googleapis.com",
+       "config": {
+         "name": "zync.googleapis.com",
+         "title": "Zync Render API"
+       },
+       "state": "DISABLED"
+     },
+     "@type": "type.googleapis.com/google.api.serviceusage.v0.DisableServiceResponse"
+   }
+ },
+ "insertId": "ftwjblc00c",
+ "resource": {
+   "type": "audited_resource",
+   "labels": {
+     "method": "google.api.serviceusage.v0.ServiceUsage.DisableService",
+     "project_id": "my-project",
+     "service": "serviceusage.googleapis.com"
+   }
+ },
+ "timestamp": "0000-00-00T00:00:00.000000000Z",
+ "severity": "NOTICE",
+ "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+ "operation": {
+   "id": "operations/acf.00000eb0-c0da-000e-b000-00eca0000fc0",
+   "producer": "serviceusage.googleapis.com",
+   "last": true
+ },
+ "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+ }

--- a/tests/data/serviceusage-enable.json
+++ b/tests/data/serviceusage-enable.json
@@ -1,0 +1,61 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "user@example.com"
+    },
+    "requestMetadata": {
+      "callerIp": "0:0:0:0:0:0:0:0",
+      "callerSuppliedUserAgent": "unknown"
+    },
+    "serviceName": "serviceusage.googleapis.com",
+    "methodName": "google.api.serviceusage.v0.ServiceUsage.EnableService",
+    "authorizationInfo": [
+      {
+        "resource": "projectnumbers/000000000000/services/youtubereporting.googleapis.com",
+        "permission": "serviceusage.services.enable",
+        "granted": true
+      },
+      {
+        "resource": "services/youtubereporting.googleapis.com",
+        "permission": "servicemanagement.services.bind",
+        "granted": true
+      }
+    ],
+    "resourceName": "projects/my-project/services/youtubereporting.googleapis.com",
+    "request": {
+      "name": "projects/my-project/services/youtubereporting.googleapis.com",
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.EnableServiceRequest"
+    },
+    "response": {
+      "service": {
+        "name": "projects/000000000000/services/youtubereporting.googleapis.com",
+        "config": {
+          "name": "youtubereporting.googleapis.com",
+          "title": "YouTube Reporting API"
+        },
+        "state": "ENABLED"
+      },
+      "@type": "type.googleapis.com/google.api.serviceusage.v0.EnableServiceResponse"
+    }
+  },
+  "insertId": "-t0cikkc0lq",
+  "resource": {
+    "type": "audited_resource",
+    "labels": {
+      "service": "serviceusage.googleapis.com",
+      "method": "google.api.serviceusage.v0.ServiceUsage.EnableService",
+      "project_id": "my-project"
+    }
+  },
+  "timestamp": "0000-00-00T00:00:00.000000000Z",
+  "severity": "NOTICE",
+  "logName": "projects/my-project/logs/cloudaudit.googleapis.com%0Factivity",
+  "operation": {
+    "id": "operations/acf.b0ee00e0-000c-0f00-0d0b-ae0dafb0fb00",
+    "producer": "serviceusage.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "0000-00-00T00:00:00.000000000Z"
+}

--- a/tests/test_stackdriver_parser.py
+++ b/tests/test_stackdriver_parser.py
@@ -55,6 +55,8 @@ test_single_asset_log_params = [
 
     ("servicemanagement-enable-service.json", "serviceusage.services", "write", "youtubeadsreach.googleapis.com"),
     ("servicemanagement-disable-service.json", "serviceusage.services", "write", "youtubereporting.googleapis.com"),
+    ("servicemanagement-activate-service.json", "serviceusage.services", "write", "calendar-json.googleapis.com"),
+    ("servicemanagement-deactivate-service.json", "serviceusage.services", "write", "zync.googleapis.com"),
     ("serviceusage-enable.json", "serviceusage.services", "write", "youtubereporting.googleapis.com"),
     ("serviceusage-disable.json", "serviceusage.services", "write", "zync.googleapis.com"),
 

--- a/tests/test_stackdriver_parser.py
+++ b/tests/test_stackdriver_parser.py
@@ -54,7 +54,9 @@ test_single_asset_log_params = [
     ("gke-nodepool-set.json", "container.projects.locations.clusters.nodePools", "write", "example-cluster/nodePools/example-pool"),
 
     ("servicemanagement-enable-service.json", "serviceusage.services", "write", "youtubeadsreach.googleapis.com"),
+    ("servicemanagement-disable-service.json", "serviceusage.services", "write", "youtubereporting.googleapis.com"),
     ("serviceusage-enable.json", "serviceusage.services", "write", "youtubereporting.googleapis.com"),
+    ("serviceusage-disable.json", "serviceusage.services", "write", "zync.googleapis.com"),
 
 ]
 

--- a/tests/test_stackdriver_parser.py
+++ b/tests/test_stackdriver_parser.py
@@ -51,7 +51,15 @@ test_single_asset_log_params = [
     ("compute-hardened-images.json", "compute.disks", "write", "test-instance"),
     ("dataproc_createcluster.json", "dataproc.clusters", "write", "test-dataproc-cluster"),
     ("gke-cluster-update.json", "container.projects.locations.clusters", "write", "example-cluster"),
-    ("gke-nodepool-set.json", "container.projects.locations.clusters.nodePools", "write", "example-cluster/nodePools/example-pool")
+    ("gke-nodepool-set.json", "container.projects.locations.clusters.nodePools", "write", "example-cluster/nodePools/example-pool"),
+
+    ("servicemanagement-enable-service.json", "serviceusage.services", "write", "youtubeadsreach.googleapis.com"),
+    ("serviceusage-enable.json", "serviceusage.services", "write", "youtubereporting.googleapis.com"),
+
+]
+
+test_log_resource_count_params = [
+    ("serviceusage-batchenable.json", "serviceusage.services", "write", 3)
 ]
 
 @pytest.mark.parametrize(
@@ -68,3 +76,17 @@ def test_single_asset_log_messages(filename, expected_resource_type, expected_op
     assert asset_info['resource_type'] == expected_resource_type
     assert asset_info['operation_type'] == expected_operation_type
     assert asset_info['resource_name'] == expected_resource_name
+
+@pytest.mark.parametrize(
+    "filename,expected_resource_type,expected_operation_type,expected_resource_count",
+    test_log_resource_count_params
+)
+def test_log_resource_count(filename, expected_resource_type, expected_operation_type, expected_resource_count):
+    log_message = get_test_data(filename)
+
+    assets = StackdriverParser.get_assets(log_message)
+    assert len(assets) == expected_resource_count
+    asset_info = assets[0]
+
+    assert asset_info['resource_type'] == expected_resource_type
+    assert asset_info['operation_type'] == expected_operation_type


### PR DESCRIPTION
Previously, the service we were extracting from `serviceusage` log messages was always `serviceusage.googleapis.com`. This fixes the parser to pull from the correct field(s), and adds support for both _batchenable_ and _disable_. The audit logs are similar enough that calls to the `servicemanagement` api to enable/disable services also work.

Tests are added for all of these cases, and a new type of test is added for logs that contain multiple assets

The previous version looked for 'ActivateService', but in all my testing the logs' methodnames were 'EnableService'