### PR TITLE
Per policy logging

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -205,18 +205,18 @@ def callback(pubsub_message):
             })
             time.sleep(delay)
 
-        for (engine, violation) in violations:
+        for (engine, violated_policy) in violations:
             logger.debug({'log_id': log_id, 'message': 'Executing remediation'})
 
             try:
-                engine.remediate(resource, violation)
-                logs[violation]['remediated'] = True
+                engine.remediate(resource, violated_policy)
+                logs[violated_policy]['remediated'] = True
 
                 if per_project_logging:
                     project_log = {
                         'event': 'remediation',
                         'trigger_event': asset_info,
-                        'policy': str(violation)
+                        'policy': violated_policy,
                     }
                     project_logger(project_log)
 

--- a/app/run.py
+++ b/app/run.py
@@ -170,6 +170,18 @@ def callback(pubsub_message):
             'message': 'Analyzing for violations'
         })
 
+        # Fetch a list of policies and then violations.  The policy
+        # list is needed to log data about evaluated policies that are
+        # not violated by the current asset.
+
+        try:
+            policies = rpe.policies(resource)
+        except Exception as e:
+            log_failure('Exception while retrieving policies', asset_info,
+                        log_id, e)
+            pubsub_message.ack()
+            continue
+
         try:
             violations = rpe.violations(resource)
             log['violation_count'] = len(violations)


### PR DESCRIPTION
This changes real time enforcer to emit log messages for each policy, even if the resource was found to be in compliance.  This is useful for producing evidence that the enforcement was in effect.

The structure is similar to the previous, but the counts have been removed (since they'd always be 1):
```json
{
  "log_id": "-p8cng8e3225g",
  "policy": "versioning",
  "asset_info": {
    "resource_type": "storage.buckets",
    "resource_name": "01c5c681-f172-432c-85fc-3fff7e17a1e6",
    "resource_location": "us",
    "project_id": "yo-cool-project-dog",
    "method_name": "storage.buckets.create",
    "operation_type": "write"
  },
  "violation": true,
  "remediated": true
}
```
If no violation is found, `violation` is `false`.  If there was no remediation, or if remediation failed, `remediation` is `false`.