### PR TITLE
Log additional details

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -187,7 +187,8 @@ def callback(pubsub_message):
             continue
 
         # Prepare log messages
-        logs = mklogs(log_id, asset_info, policies, violations)
+        message_age = int(time.time()) - log_timestamp
+        logs = mklogs(log_id, asset_info, policies, violations, message_age)
 
         if not enforce_policy:
             logger.debug({
@@ -199,7 +200,6 @@ def callback(pubsub_message):
 
         if enforcement_delay:
             # If the log is old, subtract that from the enforcement delay
-            message_age = int(time.time()) - log_timestamp
             delay = max(0, enforcement_delay - message_age)
             logger.debug({
                 'log_id': log_id,
@@ -248,7 +248,7 @@ def log_failure(log_message, asset_info, log_id, exception):
     })
 
 
-def mklogs(log_id, asset_info, policies, violations):
+def mklogs(log_id, asset_info, policies, violations, message_age):
     logs = {}
     violated_policies = {y for x, y in violations}
     evaluated_at = int(time.time())
@@ -261,6 +261,7 @@ def mklogs(log_id, asset_info, policies, violations):
             'violation': policy in violated_policies,
             'evaluated_at': evaluated_at,
             'remediated': False,  # will be updated after remediation occurs
+            'message_age': message_age,
         }
 
     return logs


### PR DESCRIPTION
This extends asset_info to contain these fields:
- evaluated_at: the evaluation time, in seconds since the epoch
- remediated_at: the time of remediation, in seconds since the epoch
- org_id: the containing organization, or None if it can't be determined
- full_resource_name: the FRN, as determined by rpe-lib
- cai_type: the CAI type, which mapped to resource types in rpe-lib.
  Currently None for unknown CAI types.  IAM policies share the CAI type
  of their associated resource.

It also replaces message_age which was accidentally dropped.