### PR TITLE
Use appropriate rpelib version (and invalidate dockerhub's cache)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib
+rpe-lib>=0.1.28
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
Docker hub isn't getting the latest pypi packages. We don't have access to dockerhub but are trying to cut a release. Changing requirements.txt should invalidate any cache dockerhub is using when building
