### PR TITLE
Minor scalability fixes

### DIFF
--- a/app/parsers/stackdriver.py
+++ b/app/parsers/stackdriver.py
@@ -285,7 +285,10 @@ class StackdriverParser():
                 'location': prop("resource.labels.zone"),
                 'project_id': prop("resource.labels.project_id"),
             }
-            add_resource()
+
+            # Logs are sent for appengine instances, but the google api hides them and will return a 404
+            if not resource_data['name'].startswith('aef-'):
+                add_resource()
 
         elif res_type == "cloud_function":
             resource_data = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib>=1.1.3
+rpe-lib>=1.1.4
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
New rpe-lib version with cloudsql instance waiter fixes, and to_dict scalability fix. Ignore appengine flex disks because theyre hidden from google apis (always return 404s) and fill logs with exceptions