### PR TITLE
Use latest rpe-lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib>=1.1.4
+rpe-lib>=1.1.5
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
The latest RPE-lib includes terminal states for GKE clusters, so we don't wait forever for clusters that won't automatically reach a running state 