### PR TITLE
Lock this version of real-time-enforcer to rpelib 1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib>=1.1.5
+rpe-lib>=1.1.5,==1.*
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
rpelib 2.x is in the works. The interface will change in ways that break the current real-time-enforcer. This locks us to rpelib 1.x until we make the changes required for rpelib 2.x