### PR TITLE
Require rpe-lib 2.0.1+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib~=2.0
+rpe-lib>=2.0.1,<3
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
Update rpe-lib to 2.0.1 to avoid potential issue with gcp resource's to_dict() call