### PR TITLE
Set client_kwargs properly

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -153,9 +153,9 @@ def callback(pubsub_message):
             resource_creds = cb.get_credentials(
                 **resource.to_dict(),
             )
-            resource.client_kwargs.update({
+            resource.client_kwargs = {
                 'credentials': resource_creds
-            })
+            }
 
             project_logger = None
             if per_project_logging and resource.project_id is not None:


### PR DESCRIPTION
The resource client is lazy loaded, and the client_kwargs `setter` invalidates the client when the kwargs are modified. This fixes the credentials replacement so the setter is called, rather than modifying the contents in-place