### PR TITLE
Allow customization of evaluation and enforcement decisions

### DIFF
--- a/app/hooks/__init__.py
+++ b/app/hooks/__init__.py
@@ -1,0 +1,1 @@
+from .evaluation import process_evaluation

--- a/app/hooks/__init__.py
+++ b/app/hooks/__init__.py
@@ -1,1 +1,2 @@
-from .evaluation import process_evaluation
+from .evaluation import process_evaluation  # noqa: F401
+from .enforcement import process_enforcement_decision  # noqa: F401

--- a/app/hooks/__init__.py
+++ b/app/hooks/__init__.py
@@ -1,2 +1,16 @@
+# Copyright 2020 The Forseti Real Time Enforcer Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .evaluation import process_evaluation  # noqa: F401
 from .enforcement import process_enforcement_decision  # noqa: F401

--- a/app/hooks/enforcement.py
+++ b/app/hooks/enforcement.py
@@ -1,2 +1,16 @@
+# Copyright 2020 The Forseti Real Time Enforcer Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def process_enforcement_decision(decision, trigger):
     pass

--- a/app/hooks/enforcement.py
+++ b/app/hooks/enforcement.py
@@ -1,0 +1,2 @@
+def process_enforcement_decision(decision, trigger):
+    pass

--- a/app/hooks/evaluation.py
+++ b/app/hooks/evaluation.py
@@ -1,0 +1,3 @@
+# Hook to allow customization of evaluation
+def process_evaluation(evaluation, trigger):
+    pass

--- a/app/hooks/evaluation.py
+++ b/app/hooks/evaluation.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The Forseti Real Time Enforcer Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Hook to allow customization of evaluation
 def process_evaluation(evaluation, trigger):
     pass

--- a/app/lib/enforcement.py
+++ b/app/lib/enforcement.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The Forseti Real Time Enforcer Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 class EnforcementDecision:
 
     def __init__(self, evaluation, trigger):

--- a/app/lib/enforcement.py
+++ b/app/lib/enforcement.py
@@ -1,0 +1,12 @@
+from rpe.policy import Evaluation
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class EnforcementDecision(BaseModel):
+    evaluation: Evaluation
+    enforce: bool = True
+    reasons: List = Field([])
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/app/lib/enforcement.py
+++ b/app/lib/enforcement.py
@@ -1,12 +1,33 @@
-from rpe.policy import Evaluation
-from typing import List
-from pydantic import BaseModel, Field
+class EnforcementDecision:
+
+    def __init__(self, evaluation, trigger):
+        self.evaluation = evaluation
+        self.trigger = trigger
+        self.enforce = True
+        self.reasons = []
+
+        self.initial_decision()
+
+    def initial_decision(self):
+
+        # Do we need to
+        if self.evaluation.compliant:
+            self.cancel('is_compliant')
+
+        # Is it excluded from enforcement
+        if self.evaluation.excluded:
+            self.cancel('is_excluded')
+
+        # Can we
+        if not self.evaluation.remediable:
+            self.cancel('is_not_remediable')
+
+        # Does the trigger indicate we shouldn't
+        if not self.trigger.control_data.enforce:
+            self.cancel('trigger_disabled')
+
+    def cancel(self, reason):
+        self.enforce = False
+        self.reasons.append(reason)
 
 
-class EnforcementDecision(BaseModel):
-    evaluation: Evaluation
-    enforce: bool = True
-    reasons: List = Field([])
-
-    class Config:
-        arbitrary_types_allowed = True

--- a/app/parsers/models.py
+++ b/app/parsers/models.py
@@ -44,3 +44,7 @@ class ParsedMessage(BaseModel):
     class Config:
         arbitrary_types_allowed = True
         extra = 'forbid'
+
+    @property
+    def age(self):
+        return int(time.time()) - self.timestamp

--- a/app/parsers/models.py
+++ b/app/parsers/models.py
@@ -12,9 +12,10 @@
 # limitations under the License.
 
 
+import time
 from typing import List
 from rpe.resources import Resource
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # Parser-supplied metadata is arbitrary, but some fields are required
@@ -38,6 +39,7 @@ class ParsedMessage(BaseModel):
     metadata: MessageMetadata
     resources: List[Resource]
     control_data: EnforcerControlData = EnforcerControlData()
+    timestamp: int = Field(default_factory=time.time)
 
     class Config:
         arbitrary_types_allowed = True

--- a/app/run.py
+++ b/app/run.py
@@ -147,7 +147,7 @@ def callback(pubsub_message):
 
             logger.debug({
                 'message_id': message_id,
-                'message': f'Processing resource',
+                'message': 'Processing resource',
                 'resource_data': resource.to_dict(),
             })
 
@@ -179,7 +179,7 @@ def callback(pubsub_message):
             pubsub_message.ack()
             continue
 
-        logger.debug({'message_id': message_id, 'message': f'Evaluating resource against policies'})
+        logger.debug({'message_id': message_id, 'message': 'Evaluating resource against policies'})
 
         try:
             evaluations = rpe.evaluate(resource)
@@ -196,7 +196,7 @@ def callback(pubsub_message):
             continue
 
         if len(evaluations) < 1:
-            logger.debug({'message_id': message_id, 'message': f'No policies matched resource'})
+            logger.debug({'message_id': message_id, 'message': 'No policies matched resource'})
 
         # Log the results of evaluations on each policy for this resource
         for evaluation in evaluations:
@@ -236,7 +236,7 @@ def callback(pubsub_message):
             for evaluation in evaluations:
 
                 if not (evaluation.compliant or evaluation.excluded) and evaluation.remediable:
-                    logger.debug({'message_id': message_id, 'message': f'Executing remediation'})
+                    logger.debug({'message_id': message_id, 'message': 'Executing remediation'})
 
                     try:
                         evaluation.remediate()

--- a/app/run.py
+++ b/app/run.py
@@ -24,6 +24,7 @@ from parsers.stackdriver import StackdriverParser
 from parsers.cai import CaiParser
 from lib.logger import Logger
 from lib.credentials import CredentialsBroker
+import hooks
 
 # Load configuration
 app_name = os.environ.get('APP_NAME', 'forseti-realtime-enforcer')
@@ -200,6 +201,10 @@ def callback(pubsub_message):
 
         # Log the results of evaluations on each policy for this resource
         for evaluation in evaluations:
+
+            # Call hook to allow for customization
+            hooks.process_evaluation(evaluation, parsed_message)
+
             evaluation_log = {
                 'compliant': evaluation.compliant,
                 'event': 'evaluation',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib>=2.0.4,<3
+rpe-lib>=2.0.5,<3
 jmespath
 google-cloud-pubsub
 google-cloud-logging


### PR DESCRIPTION
* [x] Move the json decoding to the individual parsers
* [x] Add customization hooks for evaluations and the enforcement decision
* [x] Make `timestamp` a standard field in a message
* [x] Determine (and log) if we should remediate during evaluation