### PR TITLE
Bump to newer version of rpelib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil
-rpe-lib==2.0.12
+rpe-lib>=2.0.13
 jmespath
 google-cloud-pubsub
 google-cloud-logging==2.2.0


### PR DESCRIPTION
rpe-lib 2.0.13 includes a waiter for redis instances.